### PR TITLE
adopt producer name convention and apply refactors from tyttp

### DIFF
--- a/src/Main.idr
+++ b/src/Main.idr
@@ -1,23 +1,13 @@
 module Main
 
-import Data.Buffer
-import Data.List.Quantifiers
-import Control.Monad.Either
-import Control.Monad.Maybe
 import Generics.Derive
 import JSON
-import Node.HTTP.Server
 import TyTTP.Adapter.Node.HTTP
 import TyTTP.Adapter.Node.URI
 import TyTTP.HTTP
-import TyTTP.HTTP.Consumer
 import TyTTP.HTTP.Consumer.JSON
-import TyTTP.HTTP.Producer
 import TyTTP.HTTP.Producer.JSON
-import TyTTP.HTTP.Routing
 import TyTTP.URL
-import TyTTP.URL.Path
-import TyTTP.URL.Search
 
 %language ElabReflection
 
@@ -33,12 +23,12 @@ main = do
   http <- HTTP.require
   ignore $ HTTP.listen'
     $ (\next, ctx => mapFailure Node.Error.message (next ctx))
-    $ parseUrl' (const $ text "URL has invalid format" >=> status BAD_REQUEST)
-    :> routes' (text "Resource could not be found" >=> status NOT_FOUND) { m = Promise NodeError IO }
+    $ parseUrl' (const $ sendText "URL has invalid format" >=> status BAD_REQUEST)
+    :> routes' (sendText "Resource could not be found" >=> status NOT_FOUND) { m = Promise NodeError IO }
         [ post
-            $ path "/json"
+            $ pattern "/json"
             $ consumes' [JSON]
                 { a = Example }
-                (\ctx => text "Content cannot be parsed: \{ctx.request.body}" ctx >>= status BAD_REQUEST)
-            $ \ctx => json ctx.request.body ctx >>= status OK
+                (\ctx => sendText "Content cannot be parsed: \{ctx.request.body}" ctx >>= status BAD_REQUEST)
+            $ \ctx => sendJSON ctx.request.body ctx >>= status OK
         ]

--- a/src/TyTTP/HTTP/Producer/JSON.idr
+++ b/src/TyTTP/HTTP/Producer/JSON.idr
@@ -6,13 +6,13 @@ import TyTTP.HTTP
 import JSON
 
 export
-json :
+sendJSON :
   Applicative m
   => ToJSON j
   => j
   -> Context me u v h1 s StringHeaders a b
   -> m $ Context me u v h1 s StringHeaders a (Publisher IO e Buffer)
-json j ctx = do
+sendJSON j ctx = do
   let bodyJson = encode j
   let stream : Publisher IO e Buffer = Stream.singleton $ fromString $ bodyJson
   pure $ { response.body := stream


### PR DESCRIPTION
Breaking change:

- `json` renamed to `sendJSON` to reflect that response body stream is set, align with the new name convention in tyttp