### PR TITLE
[ fix ] add node dependency

### DIFF
--- a/tyttp-json.ipkg
+++ b/tyttp-json.ipkg
@@ -10,6 +10,7 @@ depends = tyttp
   , sop
   , elab-util
   , apache-mime-types
+  , node
 
 opts      = "--codegen node"
 sourcedir = "src"


### PR DESCRIPTION
I got a build error from the pack collection: With the latest changes to tyttp, this requires a dependency on node to build. Please note that Idris does not yet resolve transitive dependencies automatically, but there is a PR in progress to add this functionality to the compiler.