### PR TITLE
[ upstream ] adjust to latest json changes

### DIFF
--- a/src/Main.idr
+++ b/src/Main.idr
@@ -11,6 +11,8 @@ import TyTTP.URL
 
 %language ElabReflection
 
+%hide JSON.Parser.JSON
+
 record Example where
   constructor MkExample
   field : String

--- a/src/TyTTP/HTTP/Consumer/JSON.idr
+++ b/src/TyTTP/HTTP/Consumer/JSON.idr
@@ -2,10 +2,9 @@ module TyTTP.HTTP.Consumer.JSON
 
 import Data.Buffer.Ext
 import JSON
-import Language.JSON as LJ
 import TyTTP.HTTP.Consumer
 
-%hide Language.JSON.Data.JSON
+%hide JSON.Parser.JSON
 
 export
 data JSON : Type where


### PR DESCRIPTION
The latest commit of idris2-json added its own `JSON` type plus a much faster parser, thus dropping its dependency on `Language.JSON` from contrib. This PR adapts tyttp-json to these changes.